### PR TITLE
fix: Fixed basestring problem for python3. Now all tests covered by tox ...

### DIFF
--- a/src/eWRT/ws/rest/__init__.py
+++ b/src/eWRT/ws/rest/__init__.py
@@ -173,8 +173,13 @@ class MultiRESTClient(object):
         '''
         correct_urls = []
 
-        if isinstance(urls, basestring):
-            urls = [urls]
+        try:
+            if isinstance(urls, basestring):
+                urls = [urls]
+        except NameError:
+            #  basestring no longer exists in python 3, producing an error.
+            if isinstance(urls, str):
+                urls = [urls]
 
         for url in urls:
             if not url.endswith('/'):


### PR DESCRIPTION
...run again
