### PR TITLE
add: pass_through_http_exceptions for rest web services.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
       ###########################################
       ## Metadata
       name="eWRT",
-      version="0.9.1.10",
+      version="0.9.1.11",
       description='eWRT',
       author='Albert Weichselbraun, Heinz Lang, Gerhard Wohlgenannt, Johannes Duong, Norman Süsstrunk, Daniel Streiff',
       author_email='albert@weblyzard.com, lang@weblyzard.com, wohlg@ai.wu.ac.at, johannes.duong@wu.ac.at, norman.suestrunk@htwchur.ch, daniel.streiff@htwchur.ch',


### PR DESCRIPTION
This feature allows us to pass through certain types of http exceptions which is required for the new Jeremia throttling strategy.