### PR TITLE
fix: multiple math packages.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,7 +17,7 @@ import sys, os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
-sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), 
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)),
                              '../src'))
 # -- General configuration -----------------------------------------------------
 
@@ -26,7 +26,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)),
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinx.ext.mathjax', 'sphinx.ext.viewcode']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.mathjax', 'sphinx.ext.viewcode']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Re-enable support for building the weblyzard library documentation on 
   https://ewrt.readthedocs.io/en/latest/
by correcting the sphinx extensions.

