### PR TITLE
chg: remove status method on multirest client (breaks monitoring as i…

### DIFF
--- a/src/eWRT/ws/rest/__init__.py
+++ b/src/eWRT/ws/rest/__init__.py
@@ -172,12 +172,6 @@ class MultiRESTClient(object):
         except:
             return False
         
-    def status(self):
-        '''
-        :returns: the status of the Recognize web service.
-        '''
-        return self.request(path='status')
-
     @classmethod
     def fix_urls(cls, urls, user=None, password=None):
         ''' fixes the urls and put them into the correct format, to maintain


### PR DESCRIPTION
…t relies on each client's definition of status or list_profiles)